### PR TITLE
NAS-109234 / 12.0 / Fix potential division-by-zero error (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -1201,6 +1201,9 @@ class CoreService(Service):
         exception
         """
         statuses = []
+        if not params:
+            return statuses
+
         progress_step = 100 / len(params)
         current_progress = 0
 


### PR DESCRIPTION
Ensure that we don't call core.bulk with empty list of params from
restart_services_after_unlock(). Also return early in core.bulk
if no params are passed in.